### PR TITLE
feat: sha256 integrity hashes + index generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,20 @@ jobs:
 
       - name: Check JSON formatting
         run: biome format --diagnostic-level=error .
+
+  test:
+    name: Test index generator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,77 @@
-dmenu-extended-plugins
-======================
+# dmenu-extended-plugins
 
-Set of plugins for dmenu-extended
+A set of plugins for [dmenu-extended](https://github.com/markhedleyjones/dmenu-extended),
+and the plugin index it downloads to discover and verify them.
+
+## Using these plugins
+
+Plugins are installed from within dmenu-extended (`-> Settings -> Download more
+plugins`). dmenu-extended reads its plugin sources from the `plugin_repositories`
+preference; this repository is included by default. You can add your own:
+
+```json
+{
+  "plugin_repositories": [
+    "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/main",
+    "https://raw.githubusercontent.com/you/your-plugins/main"
+  ]
+}
+```
+
+Each entry is the base URL (or a local path) that contains `plugins_index.json`
+and the plugin files. dmenu-extended downloads each plugin over HTTPS and
+**verifies its `sha256` before the file is written or run** - a mismatch is
+refused. Only add repositories you trust: an installed plugin is executed.
+
+## `plugins_index.json`
+
+A JSON object keyed by plugin module name (`plugin_<name>`). Example entry:
+
+```json
+{
+  "plugin_internetSearch": {
+    "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/main/plugin_internetSearch.py",
+    "desc": "Adds search providers for faster internet searching",
+    "sha1sum": "c0478ef7b409cc686f5380c253249568dbb84d8d",
+    "sha256": "b8379d0e3315bb0b00b724a81a476c88a9608b8541a425856ef7c456f08b7fae",
+    "requirements": {
+      "dmenu-extended": ">=1.0.0",
+      "python": ">=3.9"
+    },
+    "dependencies": {
+      "python": ["pexpect"],
+      "external": [{ "name": "jrnl", "url": "https://jrnl.sh" }]
+    },
+    "verified": true
+  }
+}
+```
+
+Generated fields (do not hand-edit - see below):
+
+- **`url`** - raw download URL for the plugin file, pinned to the `main` branch.
+- **`sha1sum`** - legacy integrity hash, kept for older clients.
+- **`sha256`** - integrity hash the current client verifies against.
+
+Hand-authored metadata (preserved across regeneration):
+
+- **`desc`** - one-line human description.
+- **`requirements`** - pip-style version specifiers. `dmenu-extended` is the host
+  version, `python` the interpreter (e.g. `">=1.0.0"`).
+- **`dependencies`** (optional) - `python` is a list of pip packages, `external`
+  a list of `{name, url}` binaries the plugin needs.
+- **`verified`** - `true` if the plugin is vetted by the repository maintainers.
+
+## Regenerating the index
+
+Edit the hand-authored metadata in `plugins_index.json`, then run:
+
+```bash
+python3 generate_index.py
+```
+
+It recomputes `url`, `sha1sum` and `sha256` from the actual plugin files, drops
+obsolete fields, sorts the entries, and formats the output with biome. To add a
+new plugin, drop `plugin_<name>.py` into the repository root, add an entry with
+its metadata (the generated fields may be omitted), and re-run. `plugin_example.py`
+is a template and is intentionally not indexed.

--- a/generate_index.py
+++ b/generate_index.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Regenerate plugins_index.json.
+
+The index is the published manifest dmenu-extended downloads to discover and
+verify plugins. This script keeps the hand-authored metadata for each plugin
+(``desc``, ``requirements``, ``dependencies``, ``verified``) and regenerates
+the machine-derived fields:
+
+* ``url``     - the raw download URL, pinned to the ``main`` branch
+* ``sha1sum`` - legacy integrity hash (kept for older clients)
+* ``sha256``  - integrity hash the current client prefers
+
+Entries are written sorted by plugin name with a stable field order so the
+diff stays clean. Run it after adding or changing any plugin:
+
+    python3 generate_index.py
+
+To add a new plugin, add an entry with its metadata (the computed fields may be
+left out - they are filled in here) and re-run.
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+REPO = "markhedleyjones/dmenu-extended-plugins"
+BRANCH = "main"
+RAW_BASE = f"https://raw.githubusercontent.com/{REPO}/{BRANCH}"
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+INDEX_PATH = os.path.join(HERE, "plugins_index.json")
+EXAMPLE = "plugin_example.py"
+
+# Fields removed on regeneration (superseded by the requirements field).
+DROP_FIELDS = {"min_version", "_min_version_comment"}
+
+# Stable field order for each entry: regenerated fields first, then metadata.
+FIELD_ORDER = [
+    "url",
+    "desc",
+    "sha1sum",
+    "sha256",
+    "requirements",
+    "dependencies",
+    "verified",
+]
+
+
+def plugin_path(name):
+    return os.path.join(HERE, name + ".py")
+
+
+def file_hashes(path):
+    with open(path, "rb") as handle:
+        data = handle.read()
+    return hashlib.sha1(data).hexdigest(), hashlib.sha256(data).hexdigest()
+
+
+def regenerate_entry(name, meta):
+    path = plugin_path(name)
+    if not os.path.exists(path):
+        sys.exit(f"error: index entry '{name}' has no plugin file ({name}.py)")
+    sha1sum, sha256 = file_hashes(path)
+
+    fields = {key: value for key, value in meta.items() if key not in DROP_FIELDS}
+    fields["url"] = f"{RAW_BASE}/{name}.py"
+    fields["sha1sum"] = sha1sum
+    fields["sha256"] = sha256
+
+    ordered = {key: fields[key] for key in FIELD_ORDER if key in fields}
+    for key in sorted(fields):
+        ordered.setdefault(key, fields[key])
+    return ordered
+
+
+def warn_unindexed(indexed_names):
+    indexed_files = {name + ".py" for name in indexed_names}
+    for filename in sorted(os.listdir(HERE)):
+        if not (filename.startswith("plugin_") and filename.endswith(".py")):
+            continue
+        if filename == EXAMPLE or filename in indexed_files:
+            continue
+        print(
+            f"warning: {filename} has no index entry and will not be published",
+            file=sys.stderr,
+        )
+
+
+def biome_format(path):
+    """Canonicalise JSON with biome so the output matches the repo's formatter.
+
+    biome (a repo dev dependency) collapses short arrays onto one line, which
+    json.dump does not; without this the pre-commit biome check would reject
+    the generated file.
+    """
+    biome = shutil.which("biome")
+    if biome:
+        subprocess.run([biome, "format", "--write", path], check=True)
+        return
+    print(
+        "warning: biome not found on PATH; run 'biome format --write "
+        f"{os.path.basename(path)}' before committing",
+        file=sys.stderr,
+    )
+
+
+def main():
+    with open(INDEX_PATH) as handle:
+        index = json.load(handle)
+
+    regenerated = {name: regenerate_entry(name, meta) for name, meta in index.items()}
+    ordered_index = {name: regenerated[name] for name in sorted(regenerated)}
+
+    warn_unindexed(ordered_index)
+
+    with open(INDEX_PATH, "w") as handle:
+        json.dump(ordered_index, handle, indent=2)
+        handle.write("\n")
+    biome_format(INDEX_PATH)
+
+    print(f"wrote {INDEX_PATH} ({len(ordered_index)} plugins)")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins_index.json
+++ b/plugins_index.json
@@ -8,7 +8,8 @@
     "requirements": {
       "dmenu-extended": "0.0.0",
       "python": "2.7.0"
-    }
+    },
+    "verified": true
   },
   "plugin_systemPackageManager": {
     "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/master/plugin_systemPackageManager.py",
@@ -19,7 +20,8 @@
     "requirements": {
       "dmenu-extended": "0.0.0",
       "python": "2.7.0"
-    }
+    },
+    "verified": true
   },
   "plugin_jrnl": {
     "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/master/plugin_jrnl.py",
@@ -39,6 +41,7 @@
           "url": "https://jrnl.sh/en/stable/installation/"
         }
       ]
-    }
+    },
+    "verified": true
   }
 }

--- a/plugins_index.json
+++ b/plugins_index.json
@@ -1,22 +1,9 @@
 {
   "plugin_internetSearch": {
-    "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/master/plugin_internetSearch.py",
+    "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/main/plugin_internetSearch.py",
     "desc": "Adds search providers for faster internet searching",
-    "sha1sum": "299fa0970d045e19e4638a232d23c0b0c61ad1c8",
-    "_min_version_comment": "min_version will be depreciated after 2024-08-01, plugins should use semantic-based requirements field",
-    "min_version": 0.0,
-    "requirements": {
-      "dmenu-extended": "0.0.0",
-      "python": "2.7.0"
-    },
-    "verified": true
-  },
-  "plugin_systemPackageManager": {
-    "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/master/plugin_systemPackageManager.py",
-    "desc": "Browse, install, remove and update system packages using your package manager. Supports Arch, Debian, Gentoo, and Redhat based distributions",
-    "sha1sum": "7282745ce289c34e8cc6e23016753282277ac8b3",
-    "_min_version_comment": "min_version will be depreciated after 2024-08-01, plugins should use semantic-based requirements field",
-    "min_version": 0.0,
+    "sha1sum": "c0478ef7b409cc686f5380c253249568dbb84d8d",
+    "sha256": "b8379d0e3315bb0b00b724a81a476c88a9608b8541a425856ef7c456f08b7fae",
     "requirements": {
       "dmenu-extended": "0.0.0",
       "python": "2.7.0"
@@ -24,11 +11,10 @@
     "verified": true
   },
   "plugin_jrnl": {
-    "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/master/plugin_jrnl.py",
+    "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/main/plugin_jrnl.py",
     "desc": "Interation with 'jrnl', a command line journal that is future-proof and secure",
-    "sha1sum": "bcb5d2ec4788a972867b2d6581d68d20c9c03b4a",
-    "_min_version_comment": "min_version will be depreciated after 2024-08-01, plugins should use semantic-based required_version instead",
-    "min_version": 16.1023,
+    "sha1sum": "7cdf8126a8869ac06b121c46838ebf5222cd7bcd",
+    "sha256": "a1862cefa59c842c3a2a473267d849ce5aa34335f56d0a60b7ee606ecc30f8f1",
     "requirements": {
       "dmenu-extended": "0.0.0",
       "python": "2.7.0"
@@ -41,6 +27,17 @@
           "url": "https://jrnl.sh/en/stable/installation/"
         }
       ]
+    },
+    "verified": true
+  },
+  "plugin_systemPackageManager": {
+    "url": "https://raw.githubusercontent.com/markhedleyjones/dmenu-extended-plugins/main/plugin_systemPackageManager.py",
+    "desc": "Browse, install, remove and update system packages using your package manager. Supports Arch, Debian, Gentoo, and Redhat based distributions",
+    "sha1sum": "776d571b853203ee8f18961dc7ec942db76d3e3d",
+    "sha256": "274b40e841898bb3e3c96e1827c64384c301c3de47467841f1722764797913ec",
+    "requirements": {
+      "dmenu-extended": "0.0.0",
+      "python": "2.7.0"
     },
     "verified": true
   }

--- a/test_generate_index.py
+++ b/test_generate_index.py
@@ -1,0 +1,91 @@
+"""Tests for generate_index.py."""
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _make_repo(tmp_path, index):
+    """Lay out a throwaway plugin repo and return its directory."""
+    shutil.copy(os.path.join(HERE, "generate_index.py"), tmp_path / "generate_index.py")
+    biome = os.path.join(HERE, "biome.json")
+    if os.path.exists(biome):
+        shutil.copy(biome, tmp_path / "biome.json")
+    for name in index:
+        (tmp_path / (name + ".py")).write_text(f"# {name}\n")
+    (tmp_path / "plugins_index.json").write_text(json.dumps(index))
+    return tmp_path
+
+
+def _run(repo):
+    subprocess.run(
+        [sys.executable, str(repo / "generate_index.py")], cwd=str(repo), check=True
+    )
+    return json.loads((repo / "plugins_index.json").read_text())
+
+
+def test_regenerates_hashes_url_and_drops_min_version(tmp_path):
+    repo = _make_repo(
+        tmp_path,
+        {
+            "plugin_foo": {
+                "url": "https://old/master/plugin_foo.py",
+                "desc": "Foo plugin",
+                "sha1sum": "stale",
+                "min_version": 0.0,
+                "_min_version_comment": "obsolete",
+                "requirements": {"dmenu-extended": ">=1.0.0", "python": ">=3.9"},
+                "verified": True,
+            }
+        },
+    )
+    entry = _run(repo)["plugin_foo"]
+    data = (repo / "plugin_foo.py").read_bytes()
+
+    assert entry["sha256"] == hashlib.sha256(data).hexdigest()
+    assert entry["sha1sum"] == hashlib.sha1(data).hexdigest()
+    assert entry["url"].endswith("/main/plugin_foo.py")
+    assert "min_version" not in entry
+    assert "_min_version_comment" not in entry
+    # hand-authored metadata is preserved
+    assert entry["desc"] == "Foo plugin"
+    assert entry["verified"] is True
+    assert entry["requirements"] == {"dmenu-extended": ">=1.0.0", "python": ">=3.9"}
+
+
+def test_entries_sorted_by_name(tmp_path):
+    repo = _make_repo(
+        tmp_path,
+        {
+            "plugin_zebra": {"desc": "z", "requirements": {}},
+            "plugin_alpha": {"desc": "a", "requirements": {}},
+        },
+    )
+    assert list(_run(repo).keys()) == ["plugin_alpha", "plugin_zebra"]
+
+
+def test_idempotent(tmp_path):
+    repo = _make_repo(tmp_path, {"plugin_foo": {"desc": "f", "requirements": {}}})
+    _run(repo)
+    first = (repo / "plugins_index.json").read_text()
+    _run(repo)
+    second = (repo / "plugins_index.json").read_text()
+    assert first == second
+
+
+def test_missing_plugin_file_is_an_error(tmp_path):
+    repo = _make_repo(tmp_path, {"plugin_foo": {"desc": "f", "requirements": {}}})
+    (repo / "plugin_foo.py").unlink()
+    result = subprocess.run(
+        [sys.executable, str(repo / "generate_index.py")],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "no plugin file" in result.stderr


### PR DESCRIPTION
Phase 1 of the plugin-system hardening (client side follows). Brings the index format and tooling into line so dmenu-extended can verify plugins safely, without taking anything away from existing clients.

## Changes
- **`sha256` added** to every index entry, alongside the existing `sha1sum` (nothing removed - older clients keep working). The new client will verify `sha256` before a downloaded plugin is written or run.
- **`generate_index.py`** - regenerates the machine-derived fields (`url`, `sha1sum`, `sha256`) from the actual plugin files, preserves the hand-authored metadata (`desc`, `requirements`, `dependencies`, `verified`), drops the obsolete `min_version`, sorts entries, and formats with biome so the index is stable and diffs stay clean.
- **`url` pinned to `main`** - the index (and client) previously pointed at the deleted `master` branch, surviving only on CDN cache. This moves it onto `main`.
- The previously **stale `sha1sum`s are corrected** - the old hashes did not match the current files.
- **Tests** for the generator (hash correctness, url pinning, `min_version` removal, metadata preservation, sorting, idempotency, missing-file error) and a CI job to run them.
- **README** documents the index format, the sha256 verification, regeneration, and how to host your own repository.

Includes the earlier `verified` field work (this branch builds on it), superseding `add-verified-field`.

## Verification
- `generate_index.py` is idempotent and its output is biome-clean.
- sha256/sha1 independently confirmed against the plugin files.
- `ruff` + `biome` clean; generator tests pass.